### PR TITLE
fix: infinite installation after powercycle

### DIFF
--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -1499,7 +1499,8 @@ static gboolean process_deployment(JsonNode *req_root, GError **error)
                                 if (!userdata.install_success) {
                                         g_set_error(error, RHU_HAWKBIT_CLIENT_ERROR,
                                                 RHU_HAWKBIT_CLIENT_ERROR_STREAM_INSTALL,
-                                                "Streaming installation failed");
+                                                "Installation failed");
+                                        process_deployment_cleanup();
                                         return FALSE;
                                 }
 


### PR DESCRIPTION
When a machine power cycles while installing the update, the rauc service restarts but does not re try installing the update, and keeps the status as the deployment is running, not allowing a new distribution to be pushed until it is manually cancelled.

Now we make sure the checksum is correct to validate the file and if so, then we proceed with the installation.