### PR TITLE
feat: add Error signal to the dbus interface

### DIFF
--- a/src/download-progress.xml
+++ b/src/download-progress.xml
@@ -4,5 +4,9 @@
     <signal name="ProgressUpdate">
       <arg name="percentage" type="d"/>
     </signal>
+    <signal name="Error">
+      <arg name="process" type="s"/>
+      <arg name="error" type="s"/>
+    </signal>
   </interface>
 </node>

--- a/src/hawkbit-client.c
+++ b/src/hawkbit-client.c
@@ -1231,6 +1231,10 @@ report_err:
 
         active_action->state = ACTION_STATE_ERROR;
 
+        if (dbus_interface) {
+                download_progress_download_progress_emit_error(dbus_interface, "EDOWNLOAD", error->message);
+        }
+
 cancel:
         if (active_action->state == ACTION_STATE_CANCEL_REQUESTED)
                 active_action->state = ACTION_STATE_CANCELED;
@@ -1574,6 +1578,10 @@ static gboolean process_deployment(JsonNode *req_root, GError **error)
 
 proc_error:
         feedback(artifact->feedback_url, active_action->id, (*error)->message, "failure", "closed", NULL);
+
+        if (dbus_interface) {
+                download_progress_download_progress_emit_error(dbus_interface, "EPRODEP" ,(*error)->message);
+        }
 
 error:
         // clean up failed deployment


### PR DESCRIPTION
If the process of downloading the bundle from the hawkbit server fails, whether processing the deployment information or while downloading it, the service now emits an error signal that contains 2 string attributes
 - where the error happened
    - EPRODEP : "Error Processing Deployment" (for example insufficient space)
    - EDOWNLOAD: "Error Downloading the image" (for example SHA mismatch)
 - what happened
    - The error itself